### PR TITLE
Views have access to RequestHandler.

### DIFF
--- a/gap/templates/module/views.py
+++ b/gap/templates/module/views.py
@@ -1,6 +1,11 @@
 from gap.utils.decorators import as_view
 
 @as_view
-def module_welcome_screen(request, response):
+def module_welcome_screen(handler):
+    # handler is an instance of webapp2.RequestHandler
+    # for request, access handler.request
+    # for response, access handler.response
+    # it's possible to access RquestHandler's methods like:
+    # handler.redirect(url)
     return 'Welcome to example module'
 

--- a/gap/utils/decorators.py
+++ b/gap/utils/decorators.py
@@ -22,7 +22,7 @@ def as_view(func, methods=['get', 'post']):
 
 
     def _handle(self, *args, **kwargs):
-        response = func(self.request, self.response, *args, **kwargs)
+        response = func(self, *args, **kwargs)
         if response is not None:
             self.response.write(response)
 

--- a/gap/views.py
+++ b/gap/views.py
@@ -4,15 +4,15 @@ from StringIO import StringIO
 
 
 @as_view
-def welcome_screen(request, response):
+def welcome_screen(handler):
     return get_template("homepage.html").render({
         'project_name': 'Example project',
     })
 
 
 @as_view
-def not_found(request, response, *args, **kwargs):
-    response.set_status(404)
+def not_found(handler, *args, **kwargs):
+    handler.response.set_status(404)
     text = 'The page you are requesting was not found on this server.'
 
     from gap.conf import settings


### PR DESCRIPTION
Not sure there was a way to access RequestHandler's functions like redirect from gap's view functions.
So I replaced views input parameters self.request and self.response by a single parameter self (handler).

If this is not necessary, let me know how to get to the same result.
